### PR TITLE
fix error while unselecting

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -164,9 +164,10 @@ class SelectionSetsPlugin:
 
     def updateSelection(self, data):
         for layer in QgsMapLayerRegistry.instance().mapLayers().values():
-            layer.removeSelection()
-            try:
-                ids = data[layer.id()]
-                layer.select(ids)
-            except KeyError:
-                pass
+            if isinstance(layer, QgsVectorLayer):
+                layer.removeSelection()
+                try:
+                    ids = data[layer.id()]
+                    layer.select(ids)
+                except KeyError:
+                    pass


### PR DESCRIPTION
added check if layer is a vectorlayer to prevent error while removing selection

---

I used your plugin today and encountered a problem:
When a raster-layer (in my case a WMS-Layer) is loaded and you switch your selection-set 
than you will get an error message(see screenshot).
The problem occured using QGIS 2.12.1. 

![image](https://cloud.githubusercontent.com/assets/3533244/17262698/2be1367e-55dd-11e6-8bfc-2184027fca5f.png)
